### PR TITLE
Revert "Add direct link to submit an issue"

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -22,7 +22,7 @@ Please visit our
 All html pages are generated from plain-text Markdown (.md) files for easy editing and 
 contribution of suggested changes via pull requests. You can:
 
-* Open a "[New Issue For Facilitation Best Practices](https://github.com/aci-ref/facilitation_best_practices/issues/new)" - "([How To Create An Issue] https://help.github.com/articles/creating-an-issue/)", to describe your suggestion or question you will need a github account.  
+* Open a "[New Issue](https://help.github.com/articles/creating-an-issue/)", to describe your suggestion or question. 
 * [Fork](https://help.github.com/articles/fork-a-repo/) the "[facilitation-best-practices](https://github.com/aci-ref/facilitation_best_practices)" repository to your own GitHub account, make edits, and then submit a "[New Pull Request](https://github.com/aci-ref/facilitation_best_practices/pulls)"
 
 <h3><i>For those less familiar with GitHub</i></h3>


### PR DESCRIPTION
Reverts aci-ref/facilitation_best_practices#8

Need to update the 'master' branch first. If Sean sees this, his future PRs can be made directly to the 'gh-pages' branch.
